### PR TITLE
adds missing git and ssh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN curl -O https://bootstrap.pypa.io/get-pip.py && python get-pip.py --user
 RUN python -m pip install awscli
 
 # install fargate-cli
-ENV FARGATE_VERSION v0.3.0-pre-5-g6c463b2
+ENV FARGATE_VERSION v0.3.0
 RUN curl -SLo /usr/local/bin/fargate https://github.com/turnerlabs/fargate/releases/download/${FARGATE_VERSION}/ncd_linux_amd64 && chmod +x /usr/local/bin/fargate
 
 RUN mkdir -p /project

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ ENV DOCKER_VERSION 18.03.1
 RUN apt-get update && apt-get install --no-install-recommends -y \
     apt-transport-https \
     ca-certificates \
+    ssh \
+    git \
     curl \
     software-properties-common && \
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \


### PR DESCRIPTION
Fixes this message in circle ci...
```
Either git or ssh (required by git to clone through SSH) is not installed in the image. Falling back to CircleCI's native git client but the behavior may be different from official git. If this is an issue, please use an image that has official git and ssh installed.
```