### PR TITLE
updates fargate to v0.8.0 along with other deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,36 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
-# convenient aliases
-RUN echo "alias dc=docker-compose" >> ~/.bashrc && \
-    echo "alias f=fargate" >> ~/.bashrc
+# install cli tools
+ENV DOCKER_VERSION 19.03.6
+ENV DC_VERSION 1.25.3
+ENV FARGATE_VERSION v0.8.0
 
-# install docker
-ENV DOCKER_VERSION 18.06.3
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    apt-transport-https \
-    ca-certificates \
-    ssh \
-    git \
-    bzip2 \
-    curl \
-    software-properties-common && \
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
-    add-apt-repository \
-    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-    $(lsb_release -cs) \
-    stable" && \
-    apt-get update && apt-get install --no-install-recommends -y docker-ce=${DOCKER_VERSION}~ce~3-0~ubuntu \
-    jq \
-    python-pip && \
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+      apt-transport-https \
+      ca-certificates \
+      ssh \
+      git \
+      bzip2 \
+      curl \
+      software-properties-common \
+      jq \
+      python-pip && \
+    curl -fsSLO "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" && \
+    tar xzvf docker-${DOCKER_VERSION}.tgz --strip 1 -C /usr/local/bin docker/docker && \
+    rm docker-${DOCKER_VERSION}.tgz && \
+    curl -L https://github.com/docker/compose/releases/download/${DC_VERSION}/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \
+    chmod +x /usr/local/bin/docker-compose && \
+    curl -O https://bootstrap.pypa.io/get-pip.py && \
+    python get-pip.py --user && \
+    python -m pip install awscli && \
+    curl -SLo /usr/local/bin/fargate https://github.com/turnerlabs/fargate/releases/download/${FARGATE_VERSION}/ncd_linux_amd64 && \
+    chmod +x /usr/local/bin/fargate && \
+    mkdir -p /project && \
+    echo "alias dc=docker-compose" >> ~/.bashrc && \
+    echo "alias f=fargate" >> ~/.bashrc && \
     rm -rf /var/lib/apt/lists/*
 
-
-# install docker-compose
-ENV DC_VERSION 1.23.2
-RUN curl -L https://github.com/docker/compose/releases/download/${DC_VERSION}/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose
-
-# install aws-cli
-RUN curl -O https://bootstrap.pypa.io/get-pip.py && python get-pip.py --user
-RUN python -m pip install awscli
-
-# install fargate-cli
-ENV FARGATE_VERSION v0.7.2
-RUN curl -SLo /usr/local/bin/fargate https://github.com/turnerlabs/fargate/releases/download/${FARGATE_VERSION}/ncd_linux_amd64 && chmod +x /usr/local/bin/fargate
-
-RUN mkdir -p /project
 WORKDIR /project
 
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,15 +16,15 @@ RUN apt-get update && \
       software-properties-common \
       jq \
       python-pip && \
-    curl -fsSLO "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" && \
+    curl -sSfLO "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" && \
     tar xzvf docker-${DOCKER_VERSION}.tgz --strip 1 -C /usr/local/bin docker/docker && \
     rm docker-${DOCKER_VERSION}.tgz && \
-    curl -L https://github.com/docker/compose/releases/download/${DC_VERSION}/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \
+    curl -sSfLo /usr/local/bin/docker-compose https://github.com/docker/compose/releases/download/${DC_VERSION}/docker-compose-`uname -s`-`uname -m` && \
     chmod +x /usr/local/bin/docker-compose && \
-    curl -O https://bootstrap.pypa.io/get-pip.py && \
+    curl -sSfLO https://bootstrap.pypa.io/get-pip.py && \
     python get-pip.py --user && \
     python -m pip install awscli && \
-    curl -SLo /usr/local/bin/fargate https://github.com/turnerlabs/fargate/releases/download/${FARGATE_VERSION}/ncd_linux_amd64 && \
+    curl -sSfLo /usr/local/bin/fargate https://github.com/turnerlabs/fargate/releases/download/${FARGATE_VERSION}/ncd_linux_amd64 && \
     chmod +x /usr/local/bin/fargate && \
     mkdir -p /project && \
     echo "alias dc=docker-compose" >> ~/.bashrc && \


### PR DESCRIPTION
ubuntu 18.04
fargate 0.8.0
docker-cli 19.03.6
docker-compose 1.25.3

also removes layers to reduce image size from 195.8 MB to 144.6 MB.